### PR TITLE
feat(language): load NL

### DIFF
--- a/index.php
+++ b/index.php
@@ -74,6 +74,7 @@ Kirby::plugin('zephir/cookieconsent', [
             'de' => require_once(__DIR__ . '/translations/de.php'),
             'en' => require_once(__DIR__ . '/translations/en.php'),
             'fr' => require_once(__DIR__ . '/translations/fr.php'),
+            'nl' => require_once(__DIR__ . '/translations/nl.php'),
             'pt_PT' => require_once(__DIR__ . '/translations/pt_PT.php')
         ]
     ]


### PR DESCRIPTION
This PR ensures that the Dutch (NL) translation file is properly loaded when the site’s language is set to NL. Previously, the German translation was being loaded due to the NL translation file not being properly included, leading to incorrect language display on the site.
